### PR TITLE
Implement Extmap Type

### DIFF
--- a/extmap.go
+++ b/extmap.go
@@ -1,0 +1,46 @@
+package xtypes
+
+import (
+	"encoding/json"
+)
+
+// ExtMap represents an extended map with come useful methods for convenience.
+//
+// It almost the same as url.Values/http.Header.
+// The main purpose of this type is to put values and then marshal them to JSON.
+// This is NOT thread safe.
+type ExtMap map[string]interface{}
+
+// Get gets the value associated with the given key.
+// If there is no value associated with the key, Get returns the nil.
+func (m ExtMap) Get(key string) interface{} {
+	if m == nil {
+		return nil
+	}
+
+	return m[key]
+}
+
+// Set sets the key to value. It replaces the existing value.
+func (m ExtMap) Set(key string, value interface{}) {
+	m[key] = value
+}
+
+// Del deletes the value associated with key.
+func (m ExtMap) Del(key string) {
+	delete(m, key)
+}
+
+// Encode encodes the values into raw json bytes.
+func (m ExtMap) Encode() []byte {
+	if m == nil {
+		return nil
+	}
+
+	raw, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+
+	return raw
+}

--- a/extmap_test.go
+++ b/extmap_test.go
@@ -1,0 +1,98 @@
+package xtypes
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func TestExtMap(t *testing.T) {
+	m := make(ExtMap)
+	if m == nil {
+		t.Fatal("failed to create map")
+	}
+}
+
+func TestExtMap_Get(t *testing.T) {
+	m := make(ExtMap)
+
+	key, value := "testGet", "testValue"
+	m.Set(key, value)
+
+	if v := m.Get(key); v != value {
+		t.Fatalf("expected %s, got %s type", value, v)
+	}
+}
+
+func TestExtMap_GetNil(t *testing.T) {
+	var m ExtMap
+
+	key := "testCase"
+	expected := interface{}(nil)
+
+	if v := m.Get(key); v != nil {
+		t.Fatalf("expected %s, got %s type", expected, v)
+	}
+}
+
+func TestExtMap_Set(t *testing.T) {
+	m := make(ExtMap)
+
+	key, value := "testGet", "testValue"
+	m.Set(key, value)
+
+	if v := m.Get(key); v != value {
+		t.Fatalf("expected %s, got %s type", value, v)
+	}
+}
+
+func TestExtMap_Del(t *testing.T) {
+	m := make(ExtMap)
+
+	key, value := "testGet", "testValue"
+	m.Set(key, value)
+
+	m.Del(key)
+
+	expected := interface{}(nil)
+
+	if v := m.Get(key); v != expected {
+		t.Fatalf("expected %s, got %s type", expected, v)
+	}
+}
+
+func TestExtMap_Encode(t *testing.T) {
+	m := make(ExtMap)
+
+	key, value := "testGet", "testValue"
+	m.Set(key, value)
+
+	expected := []byte(`{"testGet":"testValue"}`)
+
+	if v := m.Encode(); !bytes.Equal(expected, v) {
+		t.Fatalf("expected %s, got %s", expected, v)
+	}
+}
+
+func TestExtMap_EncodeNil(t *testing.T) {
+	var m ExtMap
+
+	expected := []byte(nil)
+
+	if v := m.Encode(); !bytes.Equal(expected, v) {
+		t.Fatalf("expected %s, got %s", expected, v)
+	}
+}
+
+func TestExtMap_EncodeError(t *testing.T) {
+	m := make(ExtMap)
+
+	key, value := "testGet", math.NaN()
+	m.Set(key, value)
+
+	expected := []byte(nil)
+
+	if v := m.Encode(); !bytes.Equal(expected, v) {
+		t.Fatalf("expected %s, got %s", expected, v)
+	}
+}

--- a/safemap_test.go
+++ b/safemap_test.go
@@ -9,7 +9,7 @@ import (
 func TestNewSafeMap(t *testing.T) {
 	sm := NewSafeMap()
 	if sm == nil {
-		t.Fatalf("failed to get data")
+		t.Fatalf("failed to create map")
 	}
 }
 


### PR DESCRIPTION
This PR introduces Extmap which adds some convenience methods to a regular map.

The type is very similar to `url.Values` and `http.Header` from the standard library.