### PR TITLE
Implement Basic Deep Copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test: ## Run tests
 	go test ./... -coverprofile=$(COVER_OUT)
 
 bench: ## Run benchmarks
-	go test -benchmem -bench .
+	go test -benchmem -bench=. ./...
 
 cover: ## Show tests coverage
 	@if [ -f $(COVER_OUT) ]; then \

--- a/copy.go
+++ b/copy.go
@@ -1,33 +1,14 @@
 package xtypes
 
 import (
-	"bytes"
-	"encoding/gob"
 	"encoding/json"
 )
 
 func Copy(dst, src interface{}) error {
-	buf := &bytes.Buffer{}
-
-	enc := gob.NewEncoder(buf)
-	if err := enc.Encode(src); err != nil {
+	data, err := json.Marshal(src)
+	if err != nil {
 		return err
 	}
 
-	dec := gob.NewDecoder(buf)
-
-	return dec.Decode(dst)
-}
-
-func Copy2(dst, src interface{}) error {
-	buf := &bytes.Buffer{}
-
-	enc := json.NewEncoder(buf)
-	if err := enc.Encode(src); err != nil {
-		return err
-	}
-
-	dec := json.NewDecoder(buf)
-
-	return dec.Decode(dst)
+	return json.Unmarshal(data, dst)
 }

--- a/copy.go
+++ b/copy.go
@@ -1,0 +1,33 @@
+package xtypes
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
+)
+
+func Copy(dst, src interface{}) error {
+	buf := &bytes.Buffer{}
+
+	enc := gob.NewEncoder(buf)
+	if err := enc.Encode(src); err != nil {
+		return err
+	}
+
+	dec := gob.NewDecoder(buf)
+
+	return dec.Decode(dst)
+}
+
+func Copy2(dst, src interface{}) error {
+	buf := &bytes.Buffer{}
+
+	enc := json.NewEncoder(buf)
+	if err := enc.Encode(src); err != nil {
+		return err
+	}
+
+	dec := json.NewDecoder(buf)
+
+	return dec.Decode(dst)
+}

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,59 @@
+package xtypes
+
+import (
+	"reflect"
+	"testing"
+)
+
+type T1 struct {
+	Name string
+}
+
+func TestCopy(t *testing.T) {
+	v1 := &T1{Name: "rainbow"}
+	v2 := &T1{}
+
+	if err := Copy(v2, v1); err != nil {
+		t.Fatal(err)
+	}
+
+	if v1.Name != v2.Name {
+		t.Fatalf("Not Equal: expected %s => actual %s\n", v1.Name, v2.Name)
+	}
+
+	if !reflect.DeepEqual(v1, v2) {
+		t.Fatal("Not Equal: reflect")
+	}
+}
+
+func TestCopy2(t *testing.T) {
+	v1 := &T1{Name: "rainbow"}
+	v2 := &T1{}
+
+	if err := Copy2(v2, v1); err != nil {
+		t.Fatal(err)
+	}
+
+	if v1.Name != v2.Name {
+		t.Fatalf("Not Equal: expected %s => actual %s\n", v1.Name, v2.Name)
+	}
+
+	if !reflect.DeepEqual(v1, v2) {
+		t.Fatal("Not Equal: reflect")
+	}
+}
+
+// Benchmarks
+func BenchmarkCopy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Copy(&T1{Name: "rainbow"}, &T1{})
+	}
+}
+
+func BenchmarkCopy2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Copy2(&T1{Name: "rainbow"}, &T1{})
+	}
+}
+
+//

--- a/copy_test.go
+++ b/copy_test.go
@@ -10,36 +10,32 @@ type T1 struct {
 }
 
 func TestCopy(t *testing.T) {
-	v1 := &T1{Name: "rainbow"}
-	v2 := &T1{}
+	type testCase struct {
+		name string
 
-	if err := Copy(v2, v1); err != nil {
-		t.Fatal(err)
+		src *T1
+		dst *T1
 	}
 
-	if v1.Name != v2.Name {
-		t.Fatalf("Not Equal: expected %s => actual %s\n", v1.Name, v2.Name)
+	tests := []*testCase{
+		&testCase{
+			name: "VALID - Regular Struct",
+
+			src: &T1{Name: "rainbow"},
+			dst: &T1{},
+		},
 	}
 
-	if !reflect.DeepEqual(v1, v2) {
-		t.Fatal("Not Equal: reflect")
-	}
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := Copy(tc.dst, tc.src); err != nil {
+				t.Fatal(err)
+			}
 
-func TestCopy2(t *testing.T) {
-	v1 := &T1{Name: "rainbow"}
-	v2 := &T1{}
-
-	if err := Copy2(v2, v1); err != nil {
-		t.Fatal(err)
-	}
-
-	if v1.Name != v2.Name {
-		t.Fatalf("Not Equal: expected %s => actual %s\n", v1.Name, v2.Name)
-	}
-
-	if !reflect.DeepEqual(v1, v2) {
-		t.Fatal("Not Equal: reflect")
+			if !reflect.DeepEqual(tc.src, tc.dst) {
+				t.Fatal("Not Equal: reflect")
+			}
+		})
 	}
 }
 
@@ -47,12 +43,6 @@ func TestCopy2(t *testing.T) {
 func BenchmarkCopy(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Copy(&T1{Name: "rainbow"}, &T1{})
-	}
-}
-
-func BenchmarkCopy2(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		Copy2(&T1{Name: "rainbow"}, &T1{})
 	}
 }
 


### PR DESCRIPTION
This PR adds a very basic ability to perform deep copy of objects.

Explicit copying based on the data type has significant advantages over a generalised approach.
Though sometimes it's required to make a copy of unknown data type or operate on interface level.

In this case, there are a few options available to us:
1. Use `reflection`
2. Use something dumb-simple like `encoding/json`

This PR uses the second approach since the intention of the `Copy` method is to provide basic ability for copying data of almost any type, especially represent as an empty interface.

The implementation has some limitations (due to the use of the `encoding/json` package):
1. Only exported fields will be copied
2. It's slow

With that said, this method is still quite usable for testing and mocking purposes. In other words, where you have some control over the source and destination data structures, and when performance is not a concern.
